### PR TITLE
add fixes for qtcreator 4.11.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ sources = [
 
 # Building from source
 
-Please note that the build was only tested with Qt Creator 4.10.0 and other versions most likely won't work as the Qt Creator APIs tend to change even between minor version.
+Please note that the build was only tested with Qt Creator 4.11.2 and other versions most likely won't work as the Qt Creator APIs tend to change even between minor version.
 
 To build the plugin you need the qtcreator sources and libraries. So the safest way is to also build qtcreator from source.
 
@@ -47,14 +47,14 @@ Rough steps:
 # useful on debian's stock qt
 export QT_SELECT=5
 
-wget https://download.qt.io/official_releases/qtcreator/4.10/4.10.0/qt-creator-opensource-src-4.10.0.tar.xz
-tar -xf qt-creator-opensource-src-4.10.0.tar.xz
-mkdir qt-creator-opensource-src-4.10.0-build
-cd qt-creator-opensource-src-4.10.0-build
+wget https://download.qt.io/official_releases/qtcreator/4.11/4.11.2/qt-creator-opensource-src-4.11.2.tar.xz
+tar -xf qt-creator-opensource-src-4.11.2.tar.xz
+mkdir qt-creator-opensource-src-4.11.2-build
+cd qt-creator-opensource-src-4.11.2-build
 
-qmake -r ../qt-creator-opensource-src-4.10.0
+qmake -r ../qt-creator-opensource-src-4.11.2
 make -j 6
-IDE_SOURCE_TREE=$(realpath ../qt-creator-opensource-src-4.10.0)
+IDE_SOURCE_TREE=$(realpath ../qt-creator-opensource-src-4.11.2)
 IDE_BUILD_TREE=$(realpath .)
 
 cd /path/to/qtcreator-meson-plugin

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,9 +13,9 @@ steps:
 - script: |
     set -x
 
-    QTC_VERSION=4.10
-    QTC_FULL=4.10.0
-    QTC_INTERNAL=4.10.0
+    QTC_VERSION=4.11
+    QTC_FULL=4.11.2
+    QTC_INTERNAL=4.11.2
 
     sudo apt-get update
     sudo apt-get install -y --no-install-recommends p7zip libgl1-mesa-dev libsm6 libice6 libxext6 libxrender1 libfontconfig1 libdbus-1-3

--- a/src/filelistnode.cpp
+++ b/src/filelistnode.cpp
@@ -4,7 +4,7 @@
 
 namespace MesonProjectManager {
 
-FileListNode::FileListNode(std::shared_ptr<MesonBuildFileParser> parser, MesonBuildFileParser::ChunkInfo *chunk, const Utils::FileName &folderPath, int priority, MesonProject *project) :
+FileListNode::FileListNode(std::shared_ptr<MesonBuildFileParser> parser, MesonBuildFileParser::ChunkInfo *chunk, const Utils::FilePath &folderPath, int priority, MesonProject *project) :
     ProjectExplorer::VirtualFolderNode(folderPath), parser(parser), chunk(chunk), project(project)
 {
     setPriority(priority);
@@ -30,7 +30,7 @@ bool FileListNode::addFiles(const QStringList &filePaths, QStringList *notAdded)
     return true;
 }
 
-bool FileListNode::removeFiles(const QStringList &filePaths, QStringList *notRemoved)
+ProjectExplorer::RemovedFilesFromProject FileListNode::removeFiles(const QStringList &filePaths, QStringList *notRemoved)
 {
     for(const auto &fp: filePaths) {
         QString relative_fn = getRelativeFileName(fp);
@@ -39,7 +39,7 @@ bool FileListNode::removeFiles(const QStringList &filePaths, QStringList *notRem
 
     MesonProject::regenerateProjectFiles(parser.get());
     project->refresh();
-    return true;
+    return ProjectExplorer::RemovedFilesFromProject::Ok;
 }
 
 bool FileListNode::renameFile(const QString &filePath, const QString &newFilePath)
@@ -65,8 +65,8 @@ bool FileListNode::supportsAction(ProjectExplorer::ProjectAction action, const P
 
 QString FileListNode::getRelativeFileName(const QString &filePath)
 {
-    auto fn = Utils::FileName::fromString(filePath);
-    QString relative_fn = fn.relativeChildPath(Utils::FileName::fromString(parser->getProject_base())).toString();
+    auto fn = Utils::FilePath::fromString(filePath);
+    QString relative_fn = fn.relativeChildPath(Utils::FilePath::fromString(parser->getProject_base())).toString();
 
     return relative_fn;
 }

--- a/src/filelistnode.h
+++ b/src/filelistnode.h
@@ -10,10 +10,10 @@ class MesonProject;
 
 class FileListNode : public virtual ProjectExplorer::VirtualFolderNode {
 public:
-    explicit FileListNode(std::shared_ptr<MesonBuildFileParser> parser, MesonBuildFileParser::ChunkInfo *chunk, const Utils::FileName &folderPath, int priority, MesonProjectManager::MesonProject *project);
+    explicit FileListNode(std::shared_ptr<MesonBuildFileParser> parser, MesonBuildFileParser::ChunkInfo *chunk, const Utils::FilePath &folderPath, int priority, MesonProjectManager::MesonProject *project);
 
     bool addFiles(const QStringList &filePaths, QStringList *notAdded) override;
-    bool removeFiles(const QStringList &filePaths, QStringList *notRemoved) override;
+    ProjectExplorer::RemovedFilesFromProject removeFiles(const QStringList &filePaths, QStringList *notRemoved) override;
     bool renameFile(const QString &filePath, const QString &newFilePath) override;
     bool supportsAction(ProjectExplorer::ProjectAction action, const ProjectExplorer::Node *node) const override;
 

--- a/src/fixdirectoryparser.cpp
+++ b/src/fixdirectoryparser.cpp
@@ -24,7 +24,7 @@ void FixDirectoryParser::taskAdded(const ProjectExplorer::Task &task, int linked
     QString filePath = task.file.toString();
 
     if (!filePath.isEmpty())
-        editable.file = Utils::FileName::fromUserInput(m_workingDirectory.absoluteFilePath(filePath));
+        editable.file = Utils::FilePath::fromUserInput(m_workingDirectory.absoluteFilePath(filePath));
 
     IOutputParser::taskAdded(editable, linkedLines, skipLines);
 }

--- a/src/mesonbuildconfiguration.h
+++ b/src/mesonbuildconfiguration.h
@@ -13,7 +13,7 @@ public:
     explicit MesonBuildConfiguration(ProjectExplorer::Target *parent, const Core::Id &id);
 
 public:
-    void initialize(const ProjectExplorer::BuildInfo &info) override;
+    void initialize() override;
 
     ProjectExplorer::NamedWidget *createConfigWidget() override;
     BuildType buildType() const override;
@@ -44,9 +44,7 @@ class MesonBuildConfigurationFactory : public ProjectExplorer::BuildConfiguratio
 public:
     MesonBuildConfigurationFactory();
 
-    QList<ProjectExplorer::BuildInfo> availableBuilds(const ProjectExplorer::Target *parent) const override;
-    QList<ProjectExplorer::BuildInfo> availableSetups(const ProjectExplorer::Kit *k, const QString &projectPath) const override;
-
+    QList<ProjectExplorer::BuildInfo> availableBuilds( const ProjectExplorer::Kit *k, const Utils::FilePath &projectPath, bool forSetup) const override;
     ProjectExplorer::BuildInfo createBuildInfo(const ProjectExplorer::Kit *k, const QString &projectPath) const;
 
 private:

--- a/src/mesonfilesubfoldernode.cpp
+++ b/src/mesonfilesubfoldernode.cpp
@@ -4,7 +4,7 @@
 
 namespace MesonProjectManager {
 
-MesonFileSubFolderNode::MesonFileSubFolderNode(const Utils::FileName &filename) :
+MesonFileSubFolderNode::MesonFileSubFolderNode(const Utils::FilePath &filename) :
     ProjectExplorer::FolderNode(filename)
 {
 }
@@ -16,10 +16,10 @@ bool MesonFileSubFolderNode::addFiles(const QStringList &filePaths, QStringList 
     return ret->addFiles(filePaths, notAdded);
 }
 
-bool MesonFileSubFolderNode::removeFiles(const QStringList &filePaths, QStringList *notRemoved)
+ProjectExplorer::RemovedFilesFromProject MesonFileSubFolderNode::removeFiles(const QStringList &filePaths, QStringList *notRemoved)
 {
     ProjectExplorer::FolderNode *ret = getFileListNode();
-    if (!ret) return false;
+    if (!ret) return ProjectExplorer::RemovedFilesFromProject::Error;
     return ret->removeFiles(filePaths, notRemoved);
 }
 

--- a/src/mesonfilesubfoldernode.h
+++ b/src/mesonfilesubfoldernode.h
@@ -8,10 +8,10 @@ namespace MesonProjectManager {
 class MesonFileSubFolderNode: public ProjectExplorer::FolderNode
 {
 public:
-    MesonFileSubFolderNode(const Utils::FileName &filename);
+    MesonFileSubFolderNode(const Utils::FilePath &filename);
 
     bool addFiles(const QStringList &filePaths, QStringList *notAdded) override;
-    bool removeFiles(const QStringList &filePaths, QStringList *notRemoved) override;
+    ProjectExplorer::RemovedFilesFromProject removeFiles(const QStringList &filePaths, QStringList *notRemoved) override;
     bool renameFile(const QString &filePath, const QString &newFilePath) override;
     bool supportsAction(ProjectExplorer::ProjectAction action, const ProjectExplorer::Node *node) const override;
 

--- a/src/mesonproject.h
+++ b/src/mesonproject.h
@@ -86,13 +86,13 @@ class MesonProject : public ProjectExplorer::Project
     Q_OBJECT
 
 public:
-    explicit MesonProject(const Utils::FileName &proFile);
+    explicit MesonProject(const Utils::FilePath &proFile);
     ~MesonProject() override;
 
     bool setupTarget(ProjectExplorer::Target *t) override;
     QStringList filesGeneratedFrom(const QString &sourceFile) const override;
     bool needsConfiguration() const override;
-    void configureAsExampleProject(const QSet<Core::Id> &platforms) override;
+    void configureAsExampleProject() override;
     //bool requiresTargetPanel() const override;
     ProjectExplorer::ProjectImporter *projectImporter() const override;
 
@@ -108,15 +108,15 @@ public:
 
     PathResolver pathResolver;
 
-    static Utils::FileName findDefaultMesonExecutable();
+    static Utils::FilePath findDefaultMesonExecutable();
     static void regenerateProjectFiles(MesonBuildFileParser *parser);
 
 private:
     static QStringList jsonArrayToStringList(const QJsonArray arr);
     MesonBuildConfiguration *activeBuildConfiguration();
-    const Utils::FileName filename;
+    const Utils::FilePath filename;
     CppTools::CppProjectUpdater *cppCodeModelUpdater = nullptr;
-    std::vector<std::unique_ptr<ProjectExplorer::ProjectDocument>> projectDocuments;
+    ParseGuard refreshGuard;
 
 protected:
     RestoreResult fromMap(const QVariantMap &map, QString *errorMessage) override;

--- a/src/mesonprojectimporter.cpp
+++ b/src/mesonprojectimporter.cpp
@@ -9,11 +9,11 @@
 class MesonProjectImporterData
 {
 public:
-    Utils::FileName directory;
+    Utils::FilePath directory;
     QString mesonPath;
 };
 
-MesonProjectManager::MesonProjectImporter::MesonProjectImporter(const Utils::FileName &path) :
+MesonProjectManager::MesonProjectImporter::MesonProjectImporter(const Utils::FilePath &path) :
     ProjectExplorer::ProjectImporter(path)
 {
 }
@@ -23,14 +23,14 @@ QStringList MesonProjectManager::MesonProjectImporter::importCandidates()
     return {};
 }
 
-QList<void *> MesonProjectManager::MesonProjectImporter::examineDirectory(const Utils::FileName &importPath) const
+QList<void *> MesonProjectManager::MesonProjectImporter::examineDirectory(const Utils::FilePath &importPath) const
 {
     QList<void *> result;
-    auto ninjaFile = Utils::FileName(importPath).pathAppended("build.ninja");
+    auto ninjaFile = Utils::FilePath(importPath).pathAppended("build.ninja");
     if (!ninjaFile.exists())
         return result;
 
-    if (!Utils::FileName(importPath).pathAppended("meson-private").exists())
+    if (!Utils::FilePath(importPath).pathAppended("meson-private").exists())
         return result;
 
     auto data = std::make_unique<MesonProjectImporterData>();
@@ -79,7 +79,7 @@ const QList<ProjectExplorer::BuildInfo> MesonProjectManager::MesonProjectImporte
 
     ProjectExplorer::BuildInfo info(factory);
     info.buildType = ProjectExplorer::BuildConfiguration::Unknown;
-    info.displayName = data->directory.fileName(1);
+    info.displayName = data->directory.fileNameWithPathComponents(1);
     info.kitId = k->id();
     info.buildDirectory = data->directory;
     QVariantMap extraParams;

--- a/src/mesonprojectimporter.h
+++ b/src/mesonprojectimporter.h
@@ -13,11 +13,11 @@ class MesonProjectImporter: public ProjectExplorer::ProjectImporter
     Q_OBJECT
 
 public:
-    MesonProjectImporter(const Utils::FileName &path);
+    MesonProjectImporter(const Utils::FilePath &path);
     QStringList importCandidates() override;
 
 protected:
-    QList<void *> examineDirectory(const Utils::FileName &importPath) const override;
+    QList<void *> examineDirectory(const Utils::FilePath &importPath) const override;
     bool matchKit(void *data, const ProjectExplorer::Kit *k) const override;
     ProjectExplorer::Kit *createKit(void *directoryData) const override;
     const QList<ProjectExplorer::BuildInfo> buildInfoListForKit(const ProjectExplorer::Kit *k, void *directoryData) const override;

--- a/src/ninjamakestep.cpp
+++ b/src/ninjamakestep.cpp
@@ -54,9 +54,7 @@ bool NinjaMakeStep::setupPP(ProjectExplorer::ProcessParameters &pp)
     Utils::Environment env = bc->environment();
     Utils::Environment::setupEnglishOutput(&env);
     pp.setEnvironment(env);
-    pp.setCommand(Utils::FilePath::fromString(ninjaCommand()));
-    pp.setArguments(allArguments());
-    pp.resolveAll();
+    pp.setCommandLine({Utils::FilePath::fromString(ninjaCommand()), allArguments(), Utils::CommandLine::Raw});
     return true;
 }
 

--- a/src/ninjamakestepconfigwidget.cpp
+++ b/src/ninjamakestepconfigwidget.cpp
@@ -47,12 +47,7 @@ NinjaMakeStepConfigWidget::NinjaMakeStepConfigWidget(NinjaMakeStep *makeStep): P
         if (static_cast<ProjectExplorer::BuildConfiguration *>(sender())->isActive())
             updateDetails();
     });
-    connect(makeStep->project(), &ProjectExplorer::Project::activeProjectConfigurationChanged,
-            this, [this](ProjectExplorer::ProjectConfiguration *pc) {
-        if (pc && pc->isActive())
-            updateDetails();
-    });
-
+    connect(makeStep->project(), &ProjectExplorer::Project::activeBuildConfigurationChanged, this, &NinjaMakeStepConfigWidget::updateDetails);
 }
 
 void NinjaMakeStepConfigWidget::updateDetails()

--- a/src/nodes.cpp
+++ b/src/nodes.cpp
@@ -13,7 +13,7 @@
 namespace MesonProjectManager {
 
 
-MesonTargetNode::MesonTargetNode(MesonProject *project, const Utils::FileName &filename, const QVector<EditableList> &editableLists, const TargetInfo &target, const QString &buildDir) :
+MesonTargetNode::MesonTargetNode(MesonProject *project, const Utils::FilePath &filename, const QVector<EditableList> &editableLists, const TargetInfo &target, const QString &buildDir) :
     ProjectExplorer::VirtualFolderNode(filename.parentDir())
 {
     setPriority(Priorities::Target);
@@ -47,7 +47,7 @@ void MesonTargetNode::addGeneratedAndUngroupedFilesNodes(const TargetInfo &targe
 {
     QStringList generatedExtraFiles;
 
-    auto ungroupedFilesNode = std::make_unique<ProjectExplorer::VirtualFolderNode>(Utils::FileName::fromString(target.definedIn.chopped(12)));
+    auto ungroupedFilesNode = std::make_unique<ProjectExplorer::VirtualFolderNode>(Utils::FilePath::fromString(target.definedIn.chopped(12)));
     ungroupedFilesNode->setPriority(Priorities::ExtraFiles);
     if(target.editableLists.size()>0) {
         ungroupedFilesNode->setDisplayName("Other Sources");
@@ -64,12 +64,12 @@ void MesonTargetNode::addGeneratedAndUngroupedFilesNodes(const TargetInfo &targe
             continue;
         }
 
-        ungroupedFilesNode->addNestedNode(std::make_unique<ProjectExplorer::FileNode>(Utils::FileName::fromString(fname),
+        ungroupedFilesNode->addNestedNode(std::make_unique<ProjectExplorer::FileNode>(Utils::FilePath::fromString(fname),
                                                                         ProjectExplorer::FileType::Source));
         ungroupedFilesNode->setIsGenerated(false);
         const QStringList headers = getAllHeadersFor(fname);
         for (const QString &header: headers) {
-            ungroupedFilesNode->addNestedNode(std::make_unique<ProjectExplorer::FileNode>(Utils::FileName::fromString(header),
+            ungroupedFilesNode->addNestedNode(std::make_unique<ProjectExplorer::FileNode>(Utils::FilePath::fromString(header),
                                                                             ProjectExplorer::FileType::Header));
             ungroupedFilesNode->setIsGenerated(false);
         }
@@ -101,19 +101,19 @@ void MesonTargetNode::addGeneratedAndUngroupedFilesNodes(const TargetInfo &targe
         updateLongestPrefix(extraFile);
     }
 
-    const Utils::FileName baseDir = Utils::FileName::fromString(longestPrefix.join("/"));
+    const Utils::FilePath baseDir = Utils::FilePath::fromString(longestPrefix.join("/"));
     auto generatedFileNode = std::make_unique<ProjectExplorer::VirtualFolderNode>(baseDir);
     generatedFileNode->setPriority(Priorities::GeneratedFiles);
     generatedFileNode->setDisplayName("Generated Files");
 
     auto addGeneratedFile = [&generatedFileNode](const QString &file) {
-        auto node = std::make_unique<ProjectExplorer::FileNode>(Utils::FileName::fromString(file),
+        auto node = std::make_unique<ProjectExplorer::FileNode>(Utils::FilePath::fromString(file),
                                                                 ProjectExplorer::FileType::Source);
         node->setIsGenerated(true);
         generatedFileNode->addNestedNode(std::move(node));
         const QStringList headers = getAllHeadersFor(file);
         for (const QString &header: headers) {
-            auto node = std::make_unique<ProjectExplorer::FileNode>(Utils::FileName::fromString(header),
+            auto node = std::make_unique<ProjectExplorer::FileNode>(Utils::FilePath::fromString(header),
                                                                     ProjectExplorer::FileType::Header);
             node->setIsGenerated(true);
             generatedFileNode->addNestedNode(std::move(node));
@@ -140,7 +140,7 @@ bool MesonTargetNode::supportsAction(ProjectExplorer::ProjectAction action, cons
     return false;
 }
 
-MesonSubDirNode::MesonSubDirNode(const Utils::FileName &filename) :
+MesonSubDirNode::MesonSubDirNode(const Utils::FilePath &filename) :
     ProjectExplorer::FolderNode(filename.parentDir())
 {
     setPriority(Priorities::SubDir);
@@ -166,17 +166,17 @@ bool MesonRootProjectNode::supportsAction(ProjectExplorer::ProjectAction action,
 }
 
 
-SubProjectsNode::SubProjectsNode(const Utils::FileName &folderPath, const QString &displayName) :
+SubProjectsNode::SubProjectsNode(const Utils::FilePath &folderPath, const QString &displayName) :
     ProjectExplorer::FolderNode(folderPath)
 {
     setPriority(Priorities::Subproject);
     setDisplayName(displayName);
 }
 
-MesonSingleGroupTargetNode::MesonSingleGroupTargetNode(const Utils::FileName &folderPath, MesonProject *project, const EditableList &editableList, const TargetInfo &target, const QString &buildDir)
+MesonSingleGroupTargetNode::MesonSingleGroupTargetNode(const Utils::FilePath &folderPath, MesonProject *project, const EditableList &editableList, const TargetInfo &target, const QString &buildDir)
     : ProjectExplorer::VirtualFolderNode(folderPath),
       FileListNode(editableList.parser, &editableList.parser->fileList(editableList.name), folderPath, Priorities::Target, project),
-      MesonTargetNode(project, Utils::FileName(), {}, target, buildDir)
+      MesonTargetNode(project, Utils::FilePath(), {}, target, buildDir)
 {
     TreeBuilder::processEditableFileList(this, editableList);
     setPriority(Priorities::Target);

--- a/src/nodes.h
+++ b/src/nodes.h
@@ -13,7 +13,7 @@ struct TargetInfo;
 class MesonTargetNode: public virtual ProjectExplorer::VirtualFolderNode
 {
 public:
-    MesonTargetNode(MesonProject *project, const Utils::FileName &filename, const QVector<EditableList> &editableLists, const TargetInfo &target, const QString &buildDir);
+    MesonTargetNode(MesonProject *project, const Utils::FilePath &filename, const QVector<EditableList> &editableLists, const TargetInfo &target, const QString &buildDir);
     void addGeneratedAndUngroupedFilesNodes(const TargetInfo &target, const QString &buildDir);
 
     bool supportsAction(ProjectExplorer::ProjectAction action, const ProjectExplorer::Node *node) const override;
@@ -22,14 +22,14 @@ public:
 class MesonSingleGroupTargetNode: public FileListNode, public MesonTargetNode
 {
 public:
-    MesonSingleGroupTargetNode(const Utils::FileName &folderPath, MesonProjectManager::MesonProject *project, const EditableList &editableList, const TargetInfo &target, const QString &buildDir);
+    MesonSingleGroupTargetNode(const Utils::FilePath &folderPath, MesonProjectManager::MesonProject *project, const EditableList &editableList, const TargetInfo &target, const QString &buildDir);
     bool supportsAction(ProjectExplorer::ProjectAction action, const ProjectExplorer::Node *node) const override;
 };
 
 class MesonSubDirNode: public ProjectExplorer::FolderNode
 {
 public:
-    MesonSubDirNode(const Utils::FileName &filename);
+    MesonSubDirNode(const Utils::FilePath &filename);
 
     bool supportsAction(ProjectExplorer::ProjectAction action, const ProjectExplorer::Node *node) const override;
 };
@@ -44,7 +44,7 @@ public:
 class SubProjectsNode : public ProjectExplorer::FolderNode
 {
 public:
-    explicit SubProjectsNode(const Utils::FileName &folderPath, const QString &displayName = QString());
+    explicit SubProjectsNode(const Utils::FilePath &folderPath, const QString &displayName = QString());
 };
 
 

--- a/src/treebuilder.h
+++ b/src/treebuilder.h
@@ -21,9 +21,9 @@ public:
 private:
     void buildProject(ProjectExplorer::FolderNode *parent, IntroSubProject& project, const QString &buildDir);
     void addNestedNodes(ProjectExplorer::FolderNode *root, const QVector<EditableList> &editableLists, IntroSubProject &project, const QString &buildDir);
-    void setupMesonFileNode(ProjectExplorer::FolderNode *node, Utils::FileName absoluteFileName, const QVector<EditableList> &editableLists);
-    MesonSubDirNode *createMesonSubDirNode(ProjectExplorer::FolderNode *parentNode, QString parentRelativeName, Utils::FileName absoluteFileName);
-    void createOtherBuildsystemFileNode(ProjectExplorer::FolderNode *parentNode, Utils::FileName absoluteFilename);
+    void setupMesonFileNode(ProjectExplorer::FolderNode *node, Utils::FilePath absoluteFileName, const QVector<EditableList> &editableLists);
+    MesonSubDirNode *createMesonSubDirNode(ProjectExplorer::FolderNode *parentNode, QString parentRelativeName, Utils::FilePath absoluteFileName);
+    void createOtherBuildsystemFileNode(ProjectExplorer::FolderNode *parentNode, Utils::FilePath absoluteFilename);
     ProjectExplorer::FolderNode *createSubProjectsNode(ProjectExplorer::FolderNode *parentNode);
 
     MesonProject *mesonProject;


### PR DESCRIPTION
Significant changes:

- Utils::FileName renamed to Utils::FilePath
- refresh() synchronization is now controlled by ParseGuard (according
to qtcreator sources this will require more refactoring in the future)
- projectDocuments watcher utilizes new high-level API

`azure_pipelines` config is updated but I didn't tested it.

qtcreator sources are unstable, so how to deal with it?
I can think of 2 options:
1) maintain separate branches for different qtcreator versions
2) push everything into one branch and tag commits

I'd prefer the 2nd one